### PR TITLE
Fix: normalize and prioritize ion types in Config class

### DIFF
--- a/oktoberfest/utils/config.py
+++ b/oktoberfest/utils/config.py
@@ -89,13 +89,13 @@ class Config:
     @property
     def ion_types(self) -> list[str]:
         """
-        Returns the fragment ion types used for fragment annotation and for calculating percolator features.
+        Return the fragment ion types used for fragment annotation and Percolator feature calculation.
 
-        Specify fragment ion types as a concatenated string in alphabetical order (e.g. "aAbcCxXyzZ"). Default is "by".
+        Specify fragment ion types as a concatenated string in alphabetical order,
+        for example, ``"aAbcCxXyzZ"``. The default is ``"by"``.
 
-        :returns: A list of representing the fragment ion types.
+        :returns: A list representing the fragment ion types.
         """
-
         raw = self.data.get("ion_types", "yb")
         # normalize to string
         seq = "".join(map(str, raw)) if isinstance(raw, list) else str(raw)

--- a/oktoberfest/utils/config.py
+++ b/oktoberfest/utils/config.py
@@ -95,7 +95,22 @@ class Config:
 
         :returns: A list of representing the fragment ion types.
         """
-        return list(self.data.get("ion_types", "by"))
+
+        raw = self.data.get("ion_types", "yb")
+        # normalize to string
+        seq = "".join(map(str, raw)) if isinstance(raw, list) else str(raw)
+
+        # priority of ion in order
+        allowed = "ybaAcCxXzZ"
+        seen = set()
+        filtered = []
+        for ch in seq:
+            if ch in allowed and ch not in seen:
+                seen.add(ch)
+                filtered.append(ch)
+
+        filtered.sort(key=lambda ch: allowed.index(ch))
+        return filtered if filtered else ["y", "b"]
 
     @property
     def unit_mass_tolerance(self) -> Optional[str]:


### PR DESCRIPTION
The default ion order is defined in the configuration and maintained throughout the entire process. This can cause errors during peak initialization. Ion prioritization was introduced to address this issue.